### PR TITLE
Add DI registration support via IServiceCollection extension methods

### DIFF
--- a/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.DI.Tests.cs
+++ b/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.DI.Tests.cs
@@ -1,18 +1,29 @@
-using System.Linq;
+﻿using System.Linq;
 using LibreTranslate.Net.Enhanced.Constants;
 using LibreTranslate.Net.Enhanced.Models;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
 namespace LibreTranslate.Net.Enhanced.Tests;
 
-public class Tests
+public class DiTests
 {
     private LibreTranslate _libreTranslate;
+    private ServiceProvider _serviceProvider;
 
     [SetUp]
     public void Setup()
     {
-        _libreTranslate = new LibreTranslate("http://localhost:5000");
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLibreTranslate(opt => opt.Url = "http://localhost:5000");
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+        _libreTranslate = _serviceProvider.GetRequiredService<LibreTranslate>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _serviceProvider?.Dispose();
     }
 
     [Test]

--- a/LibreTranslate.Net.Enhanced/Constants/LibraryConstants.cs
+++ b/LibreTranslate.Net.Enhanced/Constants/LibraryConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace LibreTranslate.Net.Enhanced.Constants
+{
+    internal static class LibraryConstants
+    {
+        internal const string DefaultUrl = "https://libretranslate.com";
+        internal const string DefaultApiKey = "";
+    }
+}

--- a/LibreTranslate.Net.Enhanced/LibreTranslate.Net.Enhanced.csproj
+++ b/LibreTranslate.Net.Enhanced/LibreTranslate.Net.Enhanced.csproj
@@ -17,6 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 

--- a/LibreTranslate.Net.Enhanced/LibreTranslate.cs
+++ b/LibreTranslate.Net.Enhanced/LibreTranslate.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using LibreTranslate.Net.Enhanced.Constants;
 using LibreTranslate.Net.Enhanced.Models;
 using Newtonsoft.Json;
 namespace LibreTranslate.Net.Enhanced
@@ -18,14 +19,22 @@ namespace LibreTranslate.Net.Enhanced
         private readonly HttpClient _httpClient;
 
         private readonly string _apiKey;
+
+        public LibreTranslate(HttpClient httpClient, string apiKey)
+        {
+            _httpClient = httpClient;
+            _apiKey = apiKey;
+        }
+        
         /// <summary>
         /// The default contructor. The default http client base uri points to https://libretranslate.com
         /// </summary>
+        [Obsolete("This constructor is obsolete. Please use the IHttpClientFactory constructor instead.")]
         public LibreTranslate()
         {
             _httpClient = new HttpClient()
             {
-                BaseAddress = new Uri("https://libretranslate.com")
+                BaseAddress = new Uri(LibraryConstants.DefaultUrl)
             };
         }
 
@@ -34,6 +43,7 @@ namespace LibreTranslate.Net.Enhanced
         /// </summary>
         /// <param name="url"></param>
         /// <param name="apiKey"></param>
+        [Obsolete("This constructor is obsolete. Please use the IHttpClientFactory constructor instead.")]
         public LibreTranslate(string url, string apiKey = null)
         {
             _httpClient = new HttpClient()
@@ -132,7 +142,7 @@ namespace LibreTranslate.Net.Enhanced
             multipart.Add(fileContent);
             
             var response = await _httpClient.PostAsync("/translate_file", multipart);
-            var allowedStatusCodes = new int[]
+            var allowedStatusCodes = new[]
             {
                 (int)HttpStatusCode.BadRequest,
                 (int)HttpStatusCode.Forbidden,
@@ -145,7 +155,7 @@ namespace LibreTranslate.Net.Enhanced
             }
 
             var errorMessage = await response.Content.ReadAsStringAsync();
-            return new TranslationResponse()
+            return new TranslationResponse
             {
                 Error = $"Unknown error {errorMessage}"
             };

--- a/LibreTranslate.Net.Enhanced/LibreTranslateRegistrationExtensions.cs
+++ b/LibreTranslate.Net.Enhanced/LibreTranslateRegistrationExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Net.Http;
+using LibreTranslate.Net.Enhanced.Constants;
+using LibreTranslate.Net.Enhanced.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LibreTranslate.Net.Enhanced
+{
+    public static class LibreTranslateRegistrationExtensions
+    {
+        private const string HttpClientKey = "LibreTranslate.Net.Enhanced";
+        public static IServiceCollection AddLibreTranslate(this IServiceCollection services, Action<LibreTranslateConfiguration> configure = null)
+        {
+            var config = new LibreTranslateConfiguration
+            {
+                Url = LibraryConstants.DefaultUrl,
+                ApiKey = LibraryConstants.DefaultApiKey
+            };
+
+            configure?.Invoke(config);
+
+            if (!Uri.TryCreate(config.Url, UriKind.Absolute, out var uri))
+                throw new ArgumentException($"Invalid URL: {config.Url}", nameof(configure));
+
+            services.AddHttpClient(HttpClientKey, client => client.BaseAddress = uri);
+
+            return services.AddTransient(sp =>
+            {
+                var clientFactory = sp.GetRequiredService<IHttpClientFactory>();
+                var httpClient = clientFactory.CreateClient(HttpClientKey);
+
+                return new LibreTranslate(httpClient, config.ApiKey);
+            });
+        }
+
+        public static IServiceCollection AddLibreTranslate(this IServiceCollection services, string url, string apiKey = null)
+        {
+            return services.AddLibreTranslate(opt =>
+            {
+                opt.Url = url;
+                if (apiKey != null) opt.ApiKey = apiKey;
+            });
+        }
+    }
+}

--- a/LibreTranslate.Net.Enhanced/Models/LibreTranslateConfiguration.cs
+++ b/LibreTranslate.Net.Enhanced/Models/LibreTranslateConfiguration.cs
@@ -1,0 +1,8 @@
+﻿namespace LibreTranslate.Net.Enhanced.Models
+{
+    public class LibreTranslateConfiguration
+    {
+        public string Url { get; set; }
+        public string ApiKey { get; set; }
+    }
+}


### PR DESCRIPTION
Introduces AddLibreTranslate() extension method that registers LibreTranslate using IHttpClientFactory, following ASP.NET Core DI conventions. Adds LibreTranslateConfiguration model and LibraryConstants for centralized defaults. Marks direct HttpClient constructors as obsolete in favor of the DI-friendly HttpClient constructor. Includes DI-based integration tests.