### PR TITLE
Add explicit net8.0 and net10.0 targets

### DIFF
--- a/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Enhanced.Tests.csproj
+++ b/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Enhanced.Tests.csproj
@@ -1,17 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-
+        <LangVersion>14</LangVersion>
         <IsPackable>false</IsPackable>
 
         <OutputType>Library</OutputType>
+
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Tests.cs
+++ b/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Tests.cs
@@ -28,6 +28,7 @@ public class Tests
         });
         System.Threading.Tasks.Task.Run(() => translateAsyncTask).Wait();
         var spanishText = translateAsyncTask.Result;
+        Assert.NotNull(spanishText);
         Assert.AreEqual(spanishText, "¡Hola Mundo!");
     }
 
@@ -80,8 +81,8 @@ public class Tests
         var detectionResultList = _libreTranslate.DetectAsync(detect).GetAwaiter().GetResult();
         var detectionResult = detectionResultList.FirstOrDefault();
         Assert.NotNull(detectionResult);
-        Assert.Null(detectionResult.Error);
-        Assert.Less(0, detectionResult.Confidence);
+        Assert.Null(detectionResult!.Error);
+        Assert.Less(0, detectionResult!.Confidence!);
         Assert.AreEqual("it", detectionResult.Language);
     }
 

--- a/LibreTranslate.Net.Enhanced/LibreTranslate.Net.Enhanced.csproj
+++ b/LibreTranslate.Net.Enhanced/LibreTranslate.Net.Enhanced.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Andrea Luciano Damico</Authors>
         <Description>Enhanced translation library using LibreTranslate for .Net</Description>
@@ -14,6 +13,7 @@
         <PackageReleaseNotes>Added new language support</PackageReleaseNotes>
         <Version>1.6.4</Version>
         <AssemblyVersion>1.6.0</AssemblyVersion>
+        <TargetFrameworks>netstandard2.0;net10.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Extends TargetFrameworks to include net8.0 and net10.0 alongside the existing netstandard2.0, and runs tests against both runtimes.