### PR TITLE
Migrate POST requests from form-urlencoded to JSON body

### DIFF
--- a/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.DI.Tests.cs
+++ b/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.DI.Tests.cs
@@ -113,4 +113,19 @@ public class DiTests
             Assert.IsNotEmpty(language.Targets);
         }
     }
+
+    [Test]
+    public void TestSuggestion()
+    {
+        var suggestion = new Suggestion()
+        {
+            Source = "it",
+            SourceText = "ciao",
+            Target = "en",
+            TargetText = "hello"
+        };
+        
+        var suggestionResponse =  _libreTranslate.SuggestAsync(suggestion).GetAwaiter().GetResult();
+        Assert.True(suggestionResponse);
+    }
 }

--- a/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Tests.cs
+++ b/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Tests.cs
@@ -103,4 +103,19 @@ public class Tests
             Assert.IsNotEmpty(language.Targets);
         }
     }
+    
+    [Test]
+    public void TestSuggestion()
+    {
+        var suggestion = new Suggestion()
+        {
+            Source = "it",
+            SourceText = "ciao",
+            Target = "en",
+            TargetText = "hello"
+        };
+        
+        var suggestionResponse =  _libreTranslate.SuggestAsync(suggestion).GetAwaiter().GetResult();
+        Assert.True(suggestionResponse);
+    }
 }

--- a/LibreTranslate.Net.Enhanced/Constants/LanguageCode.cs
+++ b/LibreTranslate.Net.Enhanced/Constants/LanguageCode.cs
@@ -39,7 +39,7 @@ namespace LibreTranslate.Net.Enhanced.Constants
 
         public override string ToString()
         {
-            return $"{_code}";
+            return _code;
         }
 
         public static readonly LanguageCode English = new LanguageCode("en");

--- a/LibreTranslate.Net.Enhanced/LibreTranslate.cs
+++ b/LibreTranslate.Net.Enhanced/LibreTranslate.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using LibreTranslate.Net.Enhanced.Constants;
 using LibreTranslate.Net.Enhanced.Models;
+using LibreTranslate.Net.Enhanced.Utils;
 using Newtonsoft.Json;
 namespace LibreTranslate.Net.Enhanced
 {
@@ -56,7 +57,7 @@ namespace LibreTranslate.Net.Enhanced
         /// Gets the server supported languages.
         /// </summary>
         /// <returns></returns>
-        public async Task<IEnumerable<SupportedLanguages>> GetSupportedLanguagesAsync()
+        public async Task<IEnumerable<SupportedLanguages>> GetSupportedLanguagesAsync() 
         {
             return JsonConvert.DeserializeObject<IEnumerable<SupportedLanguages>>(await _httpClient.GetStringAsync("/languages"));
         }
@@ -69,22 +70,13 @@ namespace LibreTranslate.Net.Enhanced
         public async Task<string> TranslateAsync(Translate translate)
         {
             translate.ApiKey = string.IsNullOrWhiteSpace(translate.ApiKey) ? _apiKey : translate.ApiKey;
-            var formUrlEncodedContent = new FormUrlEncodedContent(new Dictionary<string, string>()
-            {
-                { "q", translate.Text },
-                { "source", translate.Source.ToString() },
-                { "target", translate.Target.ToString() },
-                { "api_key", translate.ApiKey },
-                { "format", translate.Format?.ToString() }
-            });
             var response = await _httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/translate")
             {
-                Content = formUrlEncodedContent
+                Content = RequestUtils.ToStringContent(translate),
             });
             var translatedText = JsonConvert.DeserializeObject<TranslationResponse>(await response.Content.ReadAsStringAsync());
             if (response.IsSuccessStatusCode)
             {
-                
                 return translatedText.TranslatedText;
             }
             
@@ -93,12 +85,7 @@ namespace LibreTranslate.Net.Enhanced
 
         public async Task<List<DetectResponse>> DetectAsync(Detect detect)
         {
-            var formUrlEncodedContent = new FormUrlEncodedContent(new Dictionary<string, string>()
-            {
-                { "q", detect.Text },
-                { "api_key", detect.ApiKey }
-            });
-            var response = await _httpClient.PostAsync("/detect", formUrlEncodedContent);
+            var response = await _httpClient.PostAsync("/detect", RequestUtils.ToStringContent(detect));
             var detectResponse = new List<DetectResponse>();
             if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.BadRequest)
             {
@@ -170,19 +157,12 @@ namespace LibreTranslate.Net.Enhanced
                     await response.Content.ReadAsStringAsync());
             }
 
-            return default;
+            return null;
         }
 
         public async Task<bool> SuggestAsync(Suggestion suggestion)
         {
-            var urlEncoded = new FormUrlEncodedContent(new Dictionary<string, string>()
-            {
-                { "q", suggestion.SourceText },
-                { "s", suggestion.TargetText },
-                { "source", suggestion.Source },
-                { "target", suggestion.Target }
-            });
-            var response = await _httpClient.PostAsync("/suggest", urlEncoded);
+            var response = await _httpClient.PostAsync("/suggest", RequestUtils.ToStringContent(suggestion));
             var result = JsonConvert.DeserializeObject<SuggestionResponse>(await response.Content.ReadAsStringAsync());
             return result.Success;
         }

--- a/LibreTranslate.Net.Enhanced/Models/Translate.cs
+++ b/LibreTranslate.Net.Enhanced/Models/Translate.cs
@@ -1,4 +1,5 @@
 ﻿using LibreTranslate.Net.Enhanced.Constants;
+using LibreTranslate.Net.Enhanced.Serialization;
 using Newtonsoft.Json;
 
 namespace LibreTranslate.Net.Enhanced.Models
@@ -17,11 +18,13 @@ namespace LibreTranslate.Net.Enhanced.Models
         /// The source of the current language text
         /// </summary>
         [JsonProperty("source")]
+        [JsonConverter(typeof(LanguageCodeConverter))]
         public LanguageCode Source { get; set; }
         /// <summary>
         /// The target of the language we want to convert text
         /// </summary>
         [JsonProperty("target")]
+        [JsonConverter(typeof(LanguageCodeConverter))]
         public LanguageCode Target { get; set; }
         /// <summary>
         /// The libre translate api key
@@ -32,6 +35,7 @@ namespace LibreTranslate.Net.Enhanced.Models
         /// Indicates whether the q payload is plain text or Html
         /// </summary>
         [JsonProperty("format")] 
+        [JsonConverter(typeof(TextFormatConverter))]
         public TextFormat Format { get; set; }
     }
 }

--- a/LibreTranslate.Net.Enhanced/Serialization/LanguageCodeConverter.cs
+++ b/LibreTranslate.Net.Enhanced/Serialization/LanguageCodeConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using LibreTranslate.Net.Enhanced.Constants;
+using Newtonsoft.Json;
+
+namespace LibreTranslate.Net.Enhanced.Serialization
+{
+    internal class LanguageCodeConverter : JsonConverter<LanguageCode>
+    {
+        public override void WriteJson(JsonWriter writer, LanguageCode value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override LanguageCode ReadJson(JsonReader reader, Type objectType, LanguageCode existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            return reader.Value as string;
+        }
+    }
+}

--- a/LibreTranslate.Net.Enhanced/Serialization/TextFormatConverter.cs
+++ b/LibreTranslate.Net.Enhanced/Serialization/TextFormatConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using LibreTranslate.Net.Enhanced.Constants;
+using Newtonsoft.Json;
+
+namespace LibreTranslate.Net.Enhanced.Serialization
+{
+    internal class TextFormatConverter : JsonConverter<TextFormat>
+    {
+        public override void WriteJson(JsonWriter writer, TextFormat value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override TextFormat ReadJson(JsonReader reader, Type objectType, TextFormat existingValue, bool hasExistingValue,
+            JsonSerializer serializer)
+        {
+            return reader.Value as string;
+        }
+    }
+}

--- a/LibreTranslate.Net.Enhanced/Utils/RequestUtils.cs
+++ b/LibreTranslate.Net.Enhanced/Utils/RequestUtils.cs
@@ -1,0 +1,14 @@
+﻿using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace LibreTranslate.Net.Enhanced.Utils
+{
+    internal static class RequestUtils
+    {
+        public static StringContent ToStringContent<T>(T content)
+        {
+            return new StringContent(JsonConvert.SerializeObject(content), Encoding.UTF8, "application/json");
+        }
+    }
+}


### PR DESCRIPTION
Replaces FormUrlEncodedContent with a generic RequestUtils.ToStringContent<T>() helper. Adds LanguageCodeConverter and TextFormatConverter to handle custom type serialization, and covers the suggest endpoint with integration tests.