### PR TITLE
Migrate POST requests from form-urlencoded to JSON body

### DIFF
--- a/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.DI.Tests.cs
+++ b/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.DI.Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using LibreTranslate.Net.Enhanced.Constants;
 using LibreTranslate.Net.Enhanced.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -127,5 +128,22 @@ public class DiTests
         
         var suggestionResponse =  _libreTranslate.SuggestAsync(suggestion).GetAwaiter().GetResult();
         Assert.True(suggestionResponse);
+    }
+
+    [Test]
+    public void TestBatchTranslation()
+    {
+        var request = new TranslateBatch()
+        {
+            Source = "it",
+            Target = "en",
+            Text = new List<string>() { "ciao mondo", "mondo" },
+        };
+        var response = _libreTranslate.TranslateAsync(request).GetAwaiter().GetResult();
+        Assert.NotNull(response);
+        Assert.AreEqual(2, response.TranslatedText.Count);
+        Assert.Null(response.Error);
+        Assert.AreEqual("hello world", response.TranslatedText[0]);
+        Assert.AreEqual("world",  response.TranslatedText[1]);
     }
 }

--- a/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Tests.cs
+++ b/LibreTranslate.Net.Enhanced.Tests/LibreTranslate.Net.Tests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using LibreTranslate.Net.Enhanced.Constants;
 using LibreTranslate.Net.Enhanced.Models;
@@ -117,5 +118,22 @@ public class Tests
         
         var suggestionResponse =  _libreTranslate.SuggestAsync(suggestion).GetAwaiter().GetResult();
         Assert.True(suggestionResponse);
+    }
+    
+    [Test]
+    public void TestBatchTranslation()
+    {
+        var request = new TranslateBatch()
+        {
+            Source = "it",
+            Target = "en",
+            Text = new List<string>() { "ciao mondo", "mondo" },
+        };
+        var response = _libreTranslate.TranslateAsync(request).GetAwaiter().GetResult();
+        Assert.NotNull(response);
+        Assert.AreEqual(2, response.TranslatedText.Count);
+        Assert.Null(response.Error);
+        Assert.AreEqual("hello world", response.TranslatedText[0]);
+        Assert.AreEqual("world",  response.TranslatedText[1]);
     }
 }

--- a/LibreTranslate.Net.Enhanced/LibreTranslate.cs
+++ b/LibreTranslate.Net.Enhanced/LibreTranslate.cs
@@ -83,6 +83,16 @@ namespace LibreTranslate.Net.Enhanced
             return translatedText.Error;
         }
 
+        public async Task<TranslationBatchResponse> TranslateAsync(TranslateBatch batch)
+        {
+            batch.ApiKey = string.IsNullOrWhiteSpace(batch.ApiKey) ? _apiKey : batch.ApiKey;
+            var response = await _httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Post, "/translate")
+            {
+                Content = RequestUtils.ToStringContent(batch),
+            });
+            return JsonConvert.DeserializeObject<TranslationBatchResponse>(await response.Content.ReadAsStringAsync());
+        }
+
         public async Task<List<DetectResponse>> DetectAsync(Detect detect)
         {
             var response = await _httpClient.PostAsync("/detect", RequestUtils.ToStringContent(detect));

--- a/LibreTranslate.Net.Enhanced/Models/TranslateBatch.cs
+++ b/LibreTranslate.Net.Enhanced/Models/TranslateBatch.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using LibreTranslate.Net.Enhanced.Constants;
+using LibreTranslate.Net.Enhanced.Serialization;
+using Newtonsoft.Json;
+
+namespace LibreTranslate.Net.Enhanced.Models
+{
+    public class TranslateBatch
+    {
+        /// <summary>
+        /// The text to be translated
+        /// </summary>
+        [JsonProperty("q")]
+        public List<string> Text { get; set; }
+        /// <summary>
+        /// The source of the current language text
+        /// </summary>
+        [JsonProperty("source")]
+        [JsonConverter(typeof(LanguageCodeConverter))]
+        public LanguageCode Source { get; set; }
+        /// <summary>
+        /// The target of the language we want to convert text
+        /// </summary>
+        [JsonProperty("target")]
+        [JsonConverter(typeof(LanguageCodeConverter))]
+        public LanguageCode Target { get; set; }
+        /// <summary>
+        /// The libre translate api key
+        /// </summary>
+        [JsonProperty("api_key")]
+        public string ApiKey { get; set; }
+        /// <summary>
+        /// Indicates whether the q payload is plain text or Html
+        /// </summary>
+        [JsonProperty("format")] 
+        [JsonConverter(typeof(TextFormatConverter))]
+        public TextFormat Format { get; set; }
+    }
+}

--- a/LibreTranslate.Net.Enhanced/Models/TranslationBatchResponse.cs
+++ b/LibreTranslate.Net.Enhanced/Models/TranslationBatchResponse.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace LibreTranslate.Net.Enhanced.Models
+{
+    /// <summary>
+    /// The model for the batch translation api response
+    /// </summary>
+    public class TranslationBatchResponse
+    {
+        internal TranslationBatchResponse() {}
+
+        [JsonProperty("translatedText")]
+        public List<string> TranslatedText { get; set; } = new List<string>();
+        [JsonProperty("error")] 
+        public string Error { get; set; }
+    }
+}


### PR DESCRIPTION
Replaces FormUrlEncodedContent with a generic RequestUtils.ToStringContent<T>() helper. Adds LanguageCodeConverter and TextFormatConverter to handle custom type serialization, and covers the suggest endpoint with integration tests.